### PR TITLE
fix(nginx): 修复 nginx 路径匹配问题

### DIFF
--- a/default.conf.template
+++ b/default.conf.template
@@ -6,7 +6,7 @@ server {
 
     try_files $uri $uri/ /index.html;
 
-    location /api/ {
+    location ^~ /api/ {
         proxy_next_upstream http_502 http_504 error timeout invalid_header;
 
         proxy_pass http://$BACKEND_HOST;


### PR DESCRIPTION
目前对于 /api/xxxx/xxxx.png 的情况，在匹配到 
```
/api/
```
之后还会去匹配  
```
\.(?:css(\.map)?|js(\.map)?|jpe?g|png|gif|ico|cur|heic|webp|tiff?|mp3|m4a|aac|ogg|midi?|wav|mp4|mov|webm|mpe?g|avi|ogv|flv|wmv)$ {
```
导致拿不到二维码图片